### PR TITLE
adding solution to perfect Strings

### DIFF
--- a/Recurrence/Function-Generation/Prefect-Strings/sarthak.cpp
+++ b/Recurrence/Function-Generation/Prefect-Strings/sarthak.cpp
@@ -1,0 +1,38 @@
+#include<bits/stdc++.h>
+using namespace std;
+const int mod = 1e9+7;
+int powmod(int a,int p=mod-2){
+	int res = 1;
+	while(p){
+		if(p&1)res=(res*1ll*a)%mod;
+		p>>=1;
+		a=(a*1ll*a)%mod;
+	}
+	return res;
+}
+void solve(){
+	int n,c;
+	cin>>n>>c;
+	int c2n = powmod(c,n<<1);
+	int ans = c2n;
+	int ic2 = powmod((c*1ll*c)%mod);
+	int k = (c*1ll*c2n)%mod;
+	for(int j=1;j<=n;++j){
+		if(j>1){
+			k = (k*1ll*((j<<1)-3))%mod;
+			k = (k*2ll*powmod(j))%mod;
+		}
+		k = (k*1ll*(c-1))%mod;
+		k = (k*1ll*ic2)%mod;
+		ans -= k;
+		if(ans<0)ans+=mod;
+	}
+	cout<<ans<<"\n";
+}
+int main(){
+	ios_base::sync_with_stdio(false);
+	cin.tie(NULL);
+	int t;
+	cin>>t;
+	while(t--)solve();
+}


### PR DESCRIPTION
We start with the analysis of the simple bracket sequence
First we note that a balance string might have many possible balancing, hence counting number of balancing is not equivalent to counting strings!!!

We first counter this problem by choosing only balancing such that the first balance is the smallest possible followed by the second smallest possible balance

              { [1,4],[5,6],[7,8] } > {[1,4],[5,8]} --> [a,b] represent a,b is balanced

It is also easy to see that a balance string must be of even length
let $ans[i][j]$ denote the number of strings of length $2*i$ such that the first balance occurs at length $2*j$
$$ans[i][j] = \sum_{k=1}^{i-j} {ans[j][j]*ans[i-j][k]}, \hspace{50mm} i\geq1, 1\leq{j} < {i} $$
It can be clearly seen that such formed strings are j balanced, it can be shown by contradiction that no balancing of first balance being less than j exists in such strings
$$ans[1][1] = c$$
$$ans[i][i] = c \sum_{k=1}^{i-1}ans[i-1][k] - (\frac{1}{c}) \sum_{k=1}^{i-1}ans[i][k], i > 1$$

We pair the first and last character -> $c$ ways to do so
By definition the remaining string should be balanced, hence the first term
We must remove the the strings that can have a shorter balancing but also this balancing
We notice that if the actual first balance was $2*k$, the remaining string can be balanced however we like
We have to choose one of c symmetric cases as our first and last character are fixed

We rewrite eq as follows
$$gp[i] = ans[i][i]$$
$$dp[i] = \sum_{k=1}^{i}ans[i][k]$$

Clearly by definition $dp[n]$ is the answer to the original question
Rewriting equations
$$ans[i][j] = gp[j]*dp[i-j], i\geq 1 , 1\leq j < i$$

$$gp[1] = c$$

$$dp[1] = c$$

$$gp[i] = c*dp[i-1] - (\frac{1}{c}) (dp[i]-gp[i]), i \geq 2$$ 

$$(c-1)*gp[i] = c^2dp[i-1] - dp[i], i \geq 2$$

$$dp[i] = gp[i] + \sum_{j=1}^{i-1}ans[i][j], i \geq 2$$

$$dp[i] = gp[i] + \sum_{j=1}^{i-1}gp[j]*dp[i-j], i \geq 2$$

We define
$$g[0] = 0$$

$$dp[0] = 1$$

This has an advantage to reducing base cases

$$(c-1)*gp[i] = c^2dp[i-1] - dp[i], i \geq 1$$

$$dp[i] = gp[i] + \sum_{j=1}^{i-1}gp[j]*dp[i-j], i \geq 2$$

$$dp[i] = \sum_{j=1}^{i}gp[j]*dp[i-j], (gp[i]*dp[0] = gp[i]) , i \geq 2$$

$$dp[i] = \sum_{j=1}^{i}gp[j]*dp[i-j], (gp[0]=0) i \geq 2$$

$$dp[i] = \sum_{j=1}^{i}gp[j]*dp[i-j], (manual) , i \geq 1$$

$$(c-1)*dp[i] = (c-1)\sum_{j=1}^{i}gp[j]*dp[i-j], i \geq 1$$

$$(c-1)*dp[i] = \sum_{j=1}^{i}(c^2dp[j-1]-dp[j])*dp[i-j], i \geq 1$$

$$(c-1)*dp[i] = {c^2}\sum_{j=1}^{i}dp[j-1]*dp[i-j]-\sum_{j=1}^{i}dp[j]*dp[i-j], i \geq 1$$

$$(c-2)*dp[i] = {c^2}\sum_{j=0}^{i-1}dp[j-1]*dp[i-1-j]-\sum_{j=0}^{i}dp[j]*dp[i-j], i \geq 1$$

Let the generating function

$$ D(x) = \sum_{i=0}^{\infty}dp[i]*x^i$$


$${[x^i]}(c-2)D(x) = [x^{i-1}]c^2D^2(x) - [x^i]D^2(x), i \geq 1$$

$${[x^i]}(c-2)D(x) = [x^i]xc^2D^2(x) - [x^i]D^2(x), i \geq 1$$

$$ [x^i] (xc^2-1)*D^2-(c-2)D = 0, i \geq 1$$

Equating ${[x^0]}$ , (_coeff of_ $x^0$)

$$ [x^i] (xc^2-1)*D^2-(c-2)D+c-1 = 0, i \geq 0 $$

Solving quadratic eq

$$ D = \frac{(c-2) \pm \sqrt{(c-2)^2-4(xc^2-1)(c-1)}}{2*(xc^2-1)}$$

$$ D = \frac{1}{1-xc^2} + \frac{-c \pm \sqrt{c^2-4c+4+4c-1-4xc^2(c-1)}}{2*(1-xc^2)}$$

$$ D = \frac{1}{1-xc^2} + c*\left( \frac{-1 \pm \sqrt{1-4x(c-1)}}{2*(1-xc^2)}\right)$$

The denomination is infinite gp and numerator can be solved using mclauren series, sign can be resolved using first term (_coeff of_ $x^0 = 0$)

$$ {[x^n]}D = c^{2n} - c \left( \sum_{i=1}^{i=n}{{{\frac{(2(i-1))!}{i!(i-1)!}(c-1)^i}}c^{2(n-i)}}\right)$$

Finally the factorials and powers are calculated on the fly using information of previous term

We are only summing the N terms and each term calculation will require an inverse mod calculation, hence we get

$${Time} {Complexity} = O(N)$$

We only store temporary variables

$${Space} {Complexity} = O(1)$$








